### PR TITLE
Galleries now show up after first login without reload

### DIFF
--- a/src/app/siteconfig/siteconfig.service.ts
+++ b/src/app/siteconfig/siteconfig.service.ts
@@ -13,6 +13,10 @@ export class SiteConfigService {
 
     constructor(private http: HttpClient, private errors: ErrorService) {
         this.siteconfig = new ReplaySubject<SiteConfig>();
+        this.get();
+    }
+
+    get() {
         this.http.get('/frog/siteconfig')
             .map(this.errors.extractValue, this.errors)
             .subscribe(data => {

--- a/src/app/works/gallery.service.ts
+++ b/src/app/works/gallery.service.ts
@@ -46,6 +46,8 @@ export class GalleryService {
         let galleryreq = this.http.get(url, options)
             .map(this.errors.extractValues, this.errors);
 
+        this.siteconfigservice.get();
+
         combineLatest(galleryreq, this.siteconfigservice.siteconfig).subscribe(results => {
             this._items = results[0];
             this.siteconfig = results[1];


### PR DESCRIPTION
* SiteConfig was not authorized to load before login
* And would be stale, but not reloaded after
* Pulled http request into separate call
* Manual refresh of siteconfigservice triggered on gallery load